### PR TITLE
chore(cmake): bump cmake_minimum_required to 3.22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.22)
 project(duatic_gazebo)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
Bumps `cmake_minimum_required` from 3.8 to 3.22 in all 1 `CMakeLists.txt` of this repo.

## Why

- Ubuntu 22.04 (jammy) already ships CMake 3.22, so 3.8 is an unnecessarily low floor.
- A 3.8 floor pins CMake to its 3.8-era policy defaults instead of the current behaviour.
- It is on borrowed time: on CMake 4.2.3 a 3.8 floor already emits
  `CMake Deprecation Warning: Compatibility with CMake < 3.10 will be removed from a future version`,
  while 3.22 is clean.
- It aligns this repo with the rest of the workspace — `duatic_dynaarm`, `duatic_ros2control`,
  `duatic_helpers`, `duatic_message_logger` and `duatic_control` are already at 3.22.

## Scope

Only the version line changes; every touched file is a +1/-1 diff. None of the affected files
contain policy-sensitive constructs (no `option()`, `set(... CACHE)`, `cmake_policy()` or
`find_package(Boost|Python)`), so raising the policy floor is a no-op for them.

## Testing

Verified in the dev_workspace container (ROS 2 Jazzy, CMake 3.28) with every repo of the
workspace checked out on `main`:

- baseline `colcon build --mixin release ccache --cmake-args -DBUILD_TESTING=ON` **before** the
  bump: 95 packages finished, 0 errors, no stderr output;
- the same build **after** the bump: 95 packages finished, identical package set, 0 errors,
  no new CMake warnings;
- confirmed CMake genuinely re-configured the bumped packages (their build files were
  regenerated) while already-3.22 packages were left untouched;
- positive control: temporarily setting the floor to 3.99 fails the configure step, so the
  line is demonstrably in effect and the test would have caught a regression.
